### PR TITLE
Add a link to the discussion thread for PEP 778 (symlinks in wheels)

### DIFF
--- a/docs/other_issues.md
+++ b/docs/other_issues.md
@@ -36,6 +36,9 @@ An experimental setuptools extension,
 [wheel-axle](https://github.com/karellen/wheel-axle/), implements support for
 producing a wheel containing symlinks.
 
+**PEP 778: Supporting Symlinks in Wheels** is being drafted (May 2024), see
+[this discussion thread](https://discuss.python.org/t/pep-778-supporting-symlinks-in-wheels/53824).
+
 
 ## Dropping support for old manylinux versions is difficult
 


### PR DESCRIPTION
The PEP isn't live yet, so only link to the Python Discourse thread.